### PR TITLE
build-gcc: Update and miscellaneous changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GCC Cross Compiler Toolchain Build Script
 
-![ARM GCC Build](https://github.com/mvaisakh/gcc-build/workflows/ARM%20GCC%20Build/badge.svg) ![ARM64 GCC Build](https://github.com/mvaisakh/gcc-build/workflows/ARM64%20GCC%20Build/badge.svg) ![x86_64 GCC Build](https://github.com/mvaisakh/gcc-build/workflows/x86_64%20GCC%20Build/badge.svg)
+![ARM GCC Build](https://github.com/mvaisakh/gcc-build/workflows/ARM%20GCC%20Build/badge.svg) ![ARM64 GCC Build](https://github.com/mvaisakh/gcc-build/workflows/ARM64%20GCC%20Build/badge.svg) 
 
 This is a build script intended for compiling GCC from source on Linux Distributions for aarch64 bare metal development, focusing primarily on Android Kernels.
 Everything is compiled from straight from the master branch of GCC git repository.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Everything is compiled from straight from the master branch of GCC git repositor
 * **If you are on Arch Linux:**
 
     ```bash
-    sudo pacman -S base-devel
+    sudo pacman -S base-devel clang cmake git libc++ lld lldb ninja
     ```
 
 * - [ ] **TODO:** Add other distro setup Wiki

--- a/build-gcc.sh
+++ b/build-gcc.sh
@@ -7,18 +7,17 @@ echo "* Building Bleeding Edge GCC *"
 echo "******************************"
 
 # TODO: Add more dynamic option handling
-while getopts a: flag
-do
-    case "${flag}" in
-        a) arch=${OPTARG};;
-    esac
+while getopts a: flag; do
+	case "${flag}" in
+		a) arch=${OPTARG} ;;
+	esac
 done
 
 # TODO: Better target handling
 case "${arch}" in
-    "arm") TARGET="arm-eabi" ;;
-    "arm64") TARGET="aarch64-elf" ;;
-    "x86") TARGET="x86_64-elf" ;;
+	"arm") TARGET="arm-eabi" ;;
+	"arm64") TARGET="aarch64-elf" ;;
+	"x86") TARGET="x86_64-elf" ;;
 esac
 
 export WORK_DIR="$PWD"
@@ -27,62 +26,62 @@ export PATH="$PREFIX/bin:$PATH"
 
 echo "Building Bare Metal Toolchain for ${arch} with ${TARGET} as target"
 
-download_resources () {
-    echo "Downloading Pre-requisites"
-    git clone git://sourceware.org/git/binutils-gdb.git -b master binutils --depth=1
-    git clone https://git.linaro.org/toolchain/gcc.git -b master gcc --depth=1
-    cd ${WORK_DIR}
+download_resources() {
+	echo "Downloading Pre-requisites"
+	git clone git://sourceware.org/git/binutils-gdb.git -b master binutils --depth=1
+	git clone https://git.linaro.org/toolchain/gcc.git -b master gcc --depth=1
+	cd ${WORK_DIR}
 }
 
-build_binutils () {
-    cd ${WORK_DIR}
-    echo "Building Binutils"
-    mkdir build-binutils
-    cd build-binutils
-    ../binutils/configure --target=$TARGET \
-                          --prefix="$PREFIX" \
-                          --with-sysroot \
-                          --disable-nls \
-                          --disable-docs \
-                          --disable-werror \
-                          --disable-gdb \
-                          --enable-gold \
-                          --with-pkgversion="Eva BinUtils"
-    make CFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" CXXFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" -j$(nproc --all)
-    make install -j$((`nproc -all`+2))
-    cd ../
+build_binutils() {
+	cd ${WORK_DIR}
+	echo "Building Binutils"
+	mkdir build-binutils
+	cd build-binutils
+	../binutils/configure --target=$TARGET \
+		--prefix="$PREFIX" \
+		--with-sysroot \
+		--disable-nls \
+		--disable-docs \
+		--disable-werror \
+		--disable-gdb \
+		--enable-gold \
+		--with-pkgversion="Eva BinUtils"
+	make CFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" CXXFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" -j$(nproc --all)
+	make install -j$(($(nproc -all) + 2))
+	cd ../
 }
 
-build_gcc () {
-    cd ${WORK_DIR}
-    echo "Building GCC"
-    cd gcc
-    ./contrib/download_prerequisites
-    cd ../
-    mkdir build-gcc
-    cd build-gcc
-    ../gcc/configure --target=$TARGET \
-                     --prefix="$PREFIX" \
-                     --disable-decimal-float \
-                     --disable-libffi \
-                     --disable-libgomp \
-                     --disable-libmudflap \
-                     --disable-libquadmath \
-                     --disable-libstdcxx-pch \
-                     --disable-nls \
-                     --disable-shared \
-                     --disable-docs \
-                     --enable-default-ssp \
-                     --enable-languages=c,c++ \
-                     --with-pkgversion="Eva GCC" \
-                     --with-newlib \
-                     --with-gnu-as \
-                     --with-gnu-ld \
-                     --with-sysroot
-    make CFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" CXXFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" all-gcc -j$(nproc --all)
-    make CFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" CXXFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" all-target-libgcc -j$(nproc --all)
-    make install-gcc -j$((`nproc -all`+2))
-    make install-target-libgcc -j$((`nproc -all`+2))
+build_gcc() {
+	cd ${WORK_DIR}
+	echo "Building GCC"
+	cd gcc
+	./contrib/download_prerequisites
+	cd ../
+	mkdir build-gcc
+	cd build-gcc
+	../gcc/configure --target=$TARGET \
+		--prefix="$PREFIX" \
+		--disable-decimal-float \
+		--disable-libffi \
+		--disable-libgomp \
+		--disable-libmudflap \
+		--disable-libquadmath \
+		--disable-libstdcxx-pch \
+		--disable-nls \
+		--disable-shared \
+		--disable-docs \
+		--enable-default-ssp \
+		--enable-languages=c,c++ \
+		--with-pkgversion="Eva GCC" \
+		--with-newlib \
+		--with-gnu-as \
+		--with-gnu-ld \
+		--with-sysroot
+	make CFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" CXXFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" all-gcc -j$(nproc --all)
+	make CFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" CXXFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" all-target-libgcc -j$(nproc --all)
+	make install-gcc -j$(($(nproc -all) + 2))
+	make install-target-libgcc -j$(($(nproc -all) + 2))
 
 }
 

--- a/build-gcc.sh
+++ b/build-gcc.sh
@@ -49,7 +49,7 @@ build_binutils () {
                           --enable-gold \
                           --with-pkgversion="Eva BinUtils"
     make CFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" CXXFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" -j$(nproc --all)
-    make install -j$(nproc --all)
+    make install -j$((`nproc -all`+2))
     cd ../
 }
 
@@ -81,8 +81,9 @@ build_gcc () {
                      --with-sysroot
     make CFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" CXXFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" all-gcc -j$(nproc --all)
     make CFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" CXXFLAGS="-flto -O3 -pipe -ffunction-sections -fdata-sections" all-target-libgcc -j$(nproc --all)
-    make install-gcc -j$(nproc --all)
-    make install-target-libgcc -j$(nproc --all)
+    make install-gcc -j$((`nproc -all`+2))
+    make install-target-libgcc -j$((`nproc -all`+2))
+
 }
 
 download_resources

--- a/build-lld.sh
+++ b/build-lld.sh
@@ -8,30 +8,29 @@ echo "* Building Integrated LLD *"
 echo "***************************"
 
 # TODO: Add more dynamic option handling
-while getopts a: flag
-do
-    case "${flag}" in
-        a) arch=${OPTARG};;
-    esac
+while getopts a: flag; do
+	case "${flag}" in
+		a) arch=${OPTARG} ;;
+	esac
 done
 
 # TODO: Better handling of arguments
 case "${arch}" in
-    "arm") ARCH_CLANG="ARM";;
-    "arm64") ARCH_CLANG="AArch64";;
-    "x86") ARCH_CLANG="x86-64";;
+	"arm") ARCH_CLANG="ARM" ;;
+	"arm64") ARCH_CLANG="AArch64" ;;
+	"x86") ARCH_CLANG="x86-64" ;;
 esac
 
 case "${ARCH_CLANG}" in
-    "ARM") TARGET_CLANG="arm-linux-gnueabi";;
-    "AArch64") TARGET_CLANG="aarch64-linux-gnu";;
-    "x86-64") TARGET_CLANG="x86_64-linux-gnu";;
+	"ARM") TARGET_CLANG="arm-linux-gnueabi" ;;
+	"AArch64") TARGET_CLANG="aarch64-linux-gnu" ;;
+	"x86-64") TARGET_CLANG="x86_64-linux-gnu" ;;
 esac
 
 case "${ARCH_CLANG}" in
-    "ARM") TARGET_GCC="arm-eabi";;
-    "AArch64") TARGET_GCC="aarch64-elf";;
-    "x86-64") TARGET_GCC="x86_64-elf";;
+	"ARM") TARGET_GCC="arm-eabi" ;;
+	"AArch64") TARGET_GCC="aarch64-elf" ;;
+	"x86-64") TARGET_GCC="x86_64-elf" ;;
 esac
 
 # Let's keep this as is
@@ -41,53 +40,53 @@ export PATH="$PREFIX/bin:$PATH"
 
 echo "Building Integrated lld for ${arch} with ${TARGET} as target"
 
-download_resources () {
-    echo ">"
-    echo "> Downloading LLVM for LLD"
-    echo ">"
-    git clone https://github.com/llvm/llvm-project -b main llvm --depth=1
-    cd ${WORK_DIR}
+download_resources() {
+	echo ">"
+	echo "> Downloading LLVM for LLD"
+	echo ">"
+	git clone https://github.com/llvm/llvm-project -b main llvm --depth=1
+	cd ${WORK_DIR}
 }
 
-build_lld () {
-    cd ${WORK_DIR}
-    echo ">"
-    echo "> Building LLD"
-    echo ">"
-    mkdir -p llvm/build
-    cd llvm/build
-    export INSTALL_LLD_DIR="../../../gcc-${arch}"
-    cmake -G "Ninja" \
-                         -DLLVM_ENABLE_PROJECTS=lld \
-                         -DCMAKE_CROSSCOMPILING=True \
-                         -DCMAKE_INSTALL_PREFIX="$INSTALL_LLD_DIR" \
-                         -DLLVM_DEFAULT_TARGET_TRIPLE=$TARGET_CLANG \
-                         -DLLVM_TARGET_ARCH=$ARCH_CLANG \
-                         -DLLVM_TARGETS_TO_BUILD=$ARCH_CLANG \
-                         -DCMAKE_CXX_COMPILER="$(which clang++)" \
-                         -DCMAKE_C_COMPILER=$(which clang) \
-                         -DLLVM_OPTIMIZED_TABLEGEN=True \
-                         -DLLVM_USE_LINKER=lld \
-                         -DLLVM_ENABLE_LTO=Full \
-                         -DCMAKE_BUILD_TYPE=Release \
-                         -DLLVM_BUILD_RUNTIME=Off \
-                         -DLLVM_INCLUDE_TESTS=Off \
-                         -DLLVM_INCLUDE_EXAMPLES=Off \
-                         -DLLVM_INCLUDE_BENCHMARKS=Off \
-                         -DLLVM_ENABLE_MODULES=Off \
-                         -DLLVM_ENABLE_BACKTRACES=Off \
-                         -DLLVM_PARALLEL_COMPILE_JOBS=8 \
-                         -DLLVM_PARALLEL_LINK_JOBS=4 \
-                         -DBUILD_SHARED_LIBS=Off \
-                         -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
-                         -DLLVM_ENABLE_PIC=False \
-                         ../llvm
-    ninja
-    ninja install
-    # Create proper symlinks
-    cd ${INSTALL_LLD_DIR}/bin
-    ln -s lld ${TARGET_GCC}-ld.lld
-    cd ${WORK_DIR}
+build_lld() {
+	cd ${WORK_DIR}
+	echo ">"
+	echo "> Building LLD"
+	echo ">"
+	mkdir -p llvm/build
+	cd llvm/build
+	export INSTALL_LLD_DIR="../../../gcc-${arch}"
+	cmake -G "Ninja" \
+		-DLLVM_ENABLE_PROJECTS=lld \
+		-DCMAKE_CROSSCOMPILING=True \
+		-DCMAKE_INSTALL_PREFIX="$INSTALL_LLD_DIR" \
+		-DLLVM_DEFAULT_TARGET_TRIPLE=$TARGET_CLANG \
+		-DLLVM_TARGET_ARCH=$ARCH_CLANG \
+		-DLLVM_TARGETS_TO_BUILD=$ARCH_CLANG \
+		-DCMAKE_CXX_COMPILER="$(which clang++)" \
+		-DCMAKE_C_COMPILER=$(which clang) \
+		-DLLVM_OPTIMIZED_TABLEGEN=True \
+		-DLLVM_USE_LINKER=lld \
+		-DLLVM_ENABLE_LTO=Full \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DLLVM_BUILD_RUNTIME=Off \
+		-DLLVM_INCLUDE_TESTS=Off \
+		-DLLVM_INCLUDE_EXAMPLES=Off \
+		-DLLVM_INCLUDE_BENCHMARKS=Off \
+		-DLLVM_ENABLE_MODULES=Off \
+		-DLLVM_ENABLE_BACKTRACES=Off \
+		-DLLVM_PARALLEL_COMPILE_JOBS=8 \
+		-DLLVM_PARALLEL_LINK_JOBS=4 \
+		-DBUILD_SHARED_LIBS=Off \
+		-DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
+		-DLLVM_ENABLE_PIC=False \
+		../llvm
+	ninja
+	ninja install
+	# Create proper symlinks
+	cd ${INSTALL_LLD_DIR}/bin
+	ln -s lld ${TARGET_GCC}-ld.lld
+	cd ${WORK_DIR}
 }
 
 download_resources


### PR DESCRIPTION
- build-gcc: Increment parallel jobs by 2.
- README: Update Arch Linux prerequiste dependencies.
- README: Remove reduntant x86_64 GCC CI badge.
- treewide: Format shell programs with shfmt.