### PR TITLE
strip-binaries: refactor and optimize

### DIFF
--- a/strip-binaries.sh
+++ b/strip-binaries.sh
@@ -1,27 +1,28 @@
 #!/bin/bash
 
 CUR_DIR=$(pwd)
+PROTON="https://github.com/kdrag0n/proton-clang/raw/master/bin"
+A64S=aarch64-linux-gnu-strip && A32S=arm-linux-gnueabi-strip
 
-curl -LSsO "https://github.com/kdrag0n/proton-clang/raw/master/bin/strip"
-chmod +x "$CUR_DIR/strip"
-X86_STRIP="$CUR_DIR/strip"
-find "$CUR_DIR" -type f -exec file {} \; \
-    | grep "x86" | grep "not strip" | grep -v "relocatable" \
-	| tr ':' ' ' | awk '{print $1}' \
-	| while read -r file; do $X86_STRIP "$file"; done && rm "$CUR_DIR/strip"
+curl -LSsO "$PROTON/strip" && chmod +x "$CUR_DIR/strip" && X86_STRIP="$CUR_DIR/strip"
+curl -LSsO "$PROTON/$A64S" && chmod +x "$CUR_DIR/$A64S" && A64_STRIP="$CUR_DIR/$A64S"
+curl -LSsO "$PROTON/$A32S" && chmod +x "$CUR_DIR/$A32S" && A32_STRIP="$CUR_DIR/$A32S"
 
-curl -LSsO "https://github.com/kdrag0n/proton-clang/raw/master/bin/aarch64-linux-gnu-strip"
-chmod +x "$CUR_DIR/aarch64-linux-gnu-strip"
-ARM64_STRIP="$CUR_DIR/aarch64-linux-gnu-strip"
-find "$CUR_DIR" -type f -exec file {} \; \
-    | grep "ARM" | grep "aarch64" | grep "not strip" | grep -v "relocatable" \
-	| tr ':' ' ' | awk '{print $1}' \
-	| while read -r file; do $ARM64_STRIP "$file"; done && rm "$CUR_DIR/aarch64-linux-gnu-strip"
+find "$CUR_DIR" -type f -exec file {} \; > .file-idx
 
-curl -LSsO "https://github.com/kdrag0n/proton-clang/raw/master/bin/arm-linux-gnueabi-strip"
-chmod +x "$CUR_DIR/arm-linux-gnueabi-strip"
-ARM32_STRIP="$CUR_DIR/arm-linux-gnueabi-strip"
-find "$CUR_DIR" -type f -exec file {} \; \
-    | grep "ARM" | grep "32.bit" | grep "not strip" | grep -v "relocatable" \
-	| tr ':' ' ' | awk '{print $1}' \
-	| while read -r file; do $ARM32_STRIP "$file"; done && rm "$CUR_DIR/arm-linux-gnueabi-strip"
+grep "x86" .file-idx \
+    | grep "not strip" | grep -v "relocatable" \
+    | tr ':' ' ' | awk '{print $1}' \
+    | while read -r file; do $X86_STRIP "$file"; done
+
+grep "ARM" .file-idx | grep "aarch64" \
+    | grep "not strip" | grep -v "relocatable" \
+    | tr ':' ' ' | awk '{print $1}' \
+    | while read -r file; do $A64_STRIP "$file"; done
+
+grep "ARM" .file-idx | grep "32.bit" \
+    | grep "not strip" | grep -v "relocatable" \
+    | tr ':' ' ' | awk '{print $1}' \
+    | while read -r file; do $A32_STRIP "$file"; done
+
+rm "$CUR_DIR/strip" "$CUR_DIR/$A64S" "$CUR_DIR/$A32S" ".file-idx"


### PR DESCRIPTION
Previously, find command was running 3 times for stripping each architecture.
Cache the initial unmodified find list to a temporary file and use it instead.

Also, implement some sanity checks for checking existing files.

Signed-off-by: Jebaitedneko <Jebaitedneko@gmail.com>