### PR TITLE
build-gcc: Turn off development mode for binutils

### DIFF
--- a/build-gcc.sh
+++ b/build-gcc.sh
@@ -36,6 +36,7 @@ download_resources() {
   echo "Downloading Pre-requisites"
   echo "Cloning binutils"
   git clone git://sourceware.org/git/binutils-gdb.git -b master binutils --depth=1
+  sed -i '/^development=/s/true/false/' binutils/bfd/development.sh
   echo "Cloned binutils!"
   echo "Cloning GCC"
   git clone git://gcc.gnu.org/git/gcc.git -b master gcc --depth=1
@@ -49,7 +50,7 @@ build_binutils() {
   mkdir build-binutils
   cd build-binutils
   env CFLAGS="$OPT_FLAGS" CXXFLAGS="$OPT_FLAGS" \
-  ../binutils/configure --target=$TARGET \
+    ../binutils/configure --target=$TARGET \
     --disable-docs \
     --disable-gdb \
     --disable-nls \
@@ -74,7 +75,7 @@ build_gcc() {
   mkdir build-gcc
   cd build-gcc
   env CFLAGS="$OPT_FLAGS" CXXFLAGS="$OPT_FLAGS" \
-  ../gcc/configure --target=$TARGET \
+    ../gcc/configure --target=$TARGET \
     --disable-decimal-float \
     --disable-docs \
     --disable-gcov \


### PR DESCRIPTION
It is disabled by default in releases, but because we use the master branch, it remains enabled by default. So, disable it.

ref: https://github.com/bminor/binutils-gdb/blob/d87bef3a7bc827fa36a69d2c334aa82f7d188d81/bfd/development.sh#L18-L19
ref: https://github.com/archlinux/svntogit-packages/blob/6d9f3e9d4d33f777107f50d5ddff002a47740117/trunk/PKGBUILD#L37-L38