### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/toolchain-build.yml
+++ b/.github/workflows/toolchain-build.yml
@@ -24,7 +24,7 @@ jobs:
       id: get-date
       run: |
         ln -sf /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-        echo ::set-output name=date::$(/bin/date -u "+%Y%m%d")
+        echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
     - name: Setup
       run: |
         sudo dnf groupinstall "Development tools" -y
@@ -66,7 +66,7 @@ jobs:
       id: get-date
       run: |
         ln -sf /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-        echo ::set-output name=date::$(/bin/date -u "+%Y%m%d")
+        echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
     - name: Setup
       run: |
         sudo dnf groupinstall "Development tools" -y

--- a/.github/workflows/toolchain-build.yml
+++ b/.github/workflows/toolchain-build.yml
@@ -24,7 +24,7 @@ jobs:
       id: get-date
       run: |
         ln -sf /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-        echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
     - name: Setup
       run: |
         sudo dnf groupinstall "Development tools" -y
@@ -66,7 +66,7 @@ jobs:
       id: get-date
       run: |
         ln -sf /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-        echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
     - name: Setup
       run: |
         sudo dnf groupinstall "Development tools" -y


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


